### PR TITLE
2024-06-07

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -421,3 +421,25 @@ implementation 'com.zhy:okhttputils:2.6.2'//鸿洋okhttputils
 还未实装的模块：
 
 数据整理，灰度图刻度，灰度图与波形图深度刻度，软件增益，
+
+## 分支：scale工具开发
+
+快速绘制刻度轴
+
+### v2.3.1base(Radan)0607
+
+1.波列图与灰度图增加进尺刻度轴和深度刻度轴
+
+2.深度刻度轴透明切浮动在图片上方
+
+3.使用波速与采样频率和采样点数计算出最大深度作为参数带入深度刻度轴
+
+4.深度刻度轴用另外的photoView 显示，两个photoView放入FrameLayout。都使用wrap_content
+
+将FrameLayout放入ScrollView。ScrollView   Fill父容器。
+
+这样深度刻度轴可以随图片放大，可以上下滚动，左右滚动。且解决了phototView没有靠左显示的视图，当生成的bmp宽度ScrollView时
+
+会靠左显示。
+
+5.更改画图时预留的ScaleHeight为动态。根据高度的缩放大小，在图像放大前先将预留的高度缩小指定倍数，放大后刚好为固定刻度高度的高度。图像放大后再将刻度轴绘画至bmp，以保持刻度轴不变。

--- a/superTracker/build.gradle
+++ b/superTracker/build.gradle
@@ -16,8 +16,8 @@ android {
         targetSdkVersion 32
         vectorDrawables.useSupportLibrary = true
 
-        versionCode 222
-        versionName "V2.2.2(radan)"
+        versionCode 231
+        versionName "V2.3.1(radan)"
 
         missingDimensionStrategy 'device', 'anyDevice'
 

--- a/superTracker/src/main/java/com/zeus/tec/model/leida/MergeCache.java
+++ b/superTracker/src/main/java/com/zeus/tec/model/leida/MergeCache.java
@@ -21,6 +21,7 @@ public class MergeCache {
     public static List<DrillPipe> DrillPipeList = new ArrayList<>();
     public static List<ProbePoint> probePointList = new ArrayList<>();
     public static float SpaceSapmle;
+    public static float sampleSpeed = 100f;//100000m/s
 
     public static double [][] originData ;
 
@@ -162,22 +163,5 @@ public class MergeCache {
 
         return num2;
     }
-
-
-    public static void drawScale (Canvas canvas){
-        float minScaleValue ;
-        double scaleWidth;
-        double scaleHeight;
-        int unitScaleNumber;
-        int backgroundColor ;
-        int scaleColor;
-        float scaleValueSize;
-        boolean isVertical;
-
-
-
-    }
-
-
 
 }

--- a/superTracker/src/main/java/com/zeus/tec/model/utils/Scale.java
+++ b/superTracker/src/main/java/com/zeus/tec/model/utils/Scale.java
@@ -3,6 +3,9 @@ package com.zeus.tec.model.utils;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.RectF;
+import android.graphics.Typeface;
 import android.graphics.fonts.Font;
 
 public class Scale {
@@ -81,9 +84,17 @@ public class Scale {
       //  pen.setTypeface()
         backgroundPaint.setColor(background);
 
+
+        //以下为雷达数据显示左侧深度刻度专用设置
+        textPen.setColor(Color.argb(255,255,255,255));
+       // textPen.setTextSize(2f);
+
+        textPen.setAntiAlias(true);
+        textPen.setStrokeWidth(3f);
+
     }
 
-
+    private Paint textPen = new Paint();
 
     public Scale(float width,float height)
     {
@@ -98,17 +109,19 @@ public class Scale {
         public float Height;
         public float Width;
     }
+
+
     public void drawScale(Canvas g, int locationX, int locationY, float width, float height)
     {
         Size.Width = width;
         Size.Height = height;
-        g.drawRect( locationX, locationY, Size.Width,Size.Height,backgroundPaint);
+        g.drawRect( locationX, locationY, Size.Width,locationY+Size.Height,backgroundPaint);
         float count = ((scaleMax - scaleMin) / sacleinterval);
         if (orientation)//垂直
         {
             float interval = (Size.Height / count);
             count++;
-            if (setverticallocation)
+            if (setverticallocation)//右侧
             {
                 for (int i = 0; i < (int)count; i++)
                 {
@@ -135,7 +148,6 @@ public class Scale {
                                 g.drawLine(Size.Width, Y, Size.Width - scaleTenLength, Y,Tenpen);
                                 g.drawText(String.valueOf(i * sacleinterval),Size.Width - scaleTenLength - ((String.valueOf(i * sacleinterval).length() -1)), Y,pen );
                             }
-
                         }
                         else
                         {
@@ -148,8 +160,9 @@ public class Scale {
                     }
                 }
             }
-            else
+            else//左侧
             {
+
                 for (int i = 0; i < (int)count; i++)
                 {
                     float Y = i * interval + locationY;
@@ -157,21 +170,21 @@ public class Scale {
                     {
                         if ((i % 10) == 0)
                         {
-
                             if (i == 0)
                             {
                                 g.drawLine(0, Y , scaleTenLength, Y,Tenpen);
-                                g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y,pen);
+                                //雷达左侧深度刻度专用设置
+                               // g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y,pen);
                             }
                             else if (i == count - 1)
                             {
                                 g.drawLine( 0, Y, scaleTenLength, Y,Tenpen);
-                                g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y- 2+locationY,pen);
+                                g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y- 2+locationY,textPen);
                             }
                             else
                             {
                                 g.drawLine( 0, Y, scaleTenLength, Y,Tenpen);
-                                g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y - 6,pen);
+                                g.drawText(String.valueOf(i * sacleinterval), scaleTenLength + 2, Y - 6,textPen);
                             }
 
                         }

--- a/superTracker/src/main/res/layout/activity_merge_sample.xml
+++ b/superTracker/src/main/res/layout/activity_merge_sample.xml
@@ -104,16 +104,33 @@
             android:orientation="horizontal"
             android:background="#ffffff"
             >
-            <com.github.chrisbanes.photoview.PhotoView
-                android:visibility="visible"
-                android:layout_weight="1"
+            <ScrollView
+                android:id="@+id/show_scro"
                 android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="match_parent"
                 android:background="#eeeeee"
-                android:layout_marginBottom="0dp"
-                android:id="@+id/sample_img"/>
+                >
+                <FrameLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    >
+                    <com.github.chrisbanes.photoview.PhotoView
+                        android:visibility="visible"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="#eeeeee"
+                        android:layout_marginBottom="0dp"
+                        android:id="@+id/sample_img"/>
+                    <com.github.chrisbanes.photoview.PhotoView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/depthscale_photo"
+                        />
 
+                </FrameLayout>
 
+            </ScrollView>
             <ScrollView
                 android:layout_width="200dp"
                 android:layout_height="match_parent"
@@ -134,14 +151,12 @@
                         android:gravity="center_vertical"
                         android:paddingLeft="10dp"
                         android:orientation="horizontal">
-
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="图像比例"
                             android:textColor="#000000"
                             android:textSize="17dp" />
-
                         <org.angmarch.views.NiceSpinner
                             android:background="#ff0000"
                             android:id="@+id/imageRatio_spinner"
@@ -156,14 +171,12 @@
                         android:gravity="center_vertical"
                         android:paddingLeft="10dp"
                         android:orientation="horizontal">
-
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="波列数量"
                             android:textColor="#000000"
                             android:textSize="17dp" />
-
                         <org.angmarch.views.NiceSpinner
                             android:id="@+id/sampleCount_spinner"
                             android:layout_width="wrap_content"
@@ -227,7 +240,6 @@
                             android:text="滤波高频"
                             android:textColor="#000000"
                             android:textSize="17dp" />
-
                         <org.angmarch.views.NiceSpinner
                             android:id="@+id/nice_spinner_highFreq"
                             android:layout_width="wrap_content"
@@ -290,9 +302,7 @@
                         />
                 </LinearLayout>
             </ScrollView>
-
         </LinearLayout>
-
        <com.wang.avi.AVLoadingIndicatorView
            android:id="@+id/loading_avi"
            android:layout_width="60dp"


### PR DESCRIPTION
### v2.3.1base(Radan)0607

1.波列图与灰度图增加进尺刻度轴和深度刻度轴

2.深度刻度轴透明切浮动在图片上方

3.使用波速与采样频率和采样点数计算出最大深度作为参数带入深度刻度轴

4.深度刻度轴用另外的photoView 显示，两个photoView放入FrameLayout。都使用wrap_content

将FrameLayout放入ScrollView。ScrollView   Fill父容器。

这样深度刻度轴可以随图片放大，可以上下滚动，左右滚动。且解决了phototView没有靠左显示的视图，当生成的bmp宽度ScrollView时

会靠左显示。

5.更改画图时预留的ScaleHeight为动态。根据高度的缩放大小，在图像放大前先将预留的高度缩小指定倍数，放大后刚好为固定刻度高度的高度。图像放大后再将刻度轴绘画至bmp，以保持刻度轴不变。